### PR TITLE
Download notice as file

### DIFF
--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -29,6 +29,11 @@ class PublicController < ApplicationController
     end
   end
 
+  def read_public
+    @data = @notice.read_data(params[:answer])
+    render :read
+  end
+
   private
 
   def get_notice

--- a/app/views/public/open.html.slim
+++ b/app/views/public/open.html.slim
@@ -21,7 +21,7 @@
       = label_tag :answer, t('notices.answer'), class: "col-lg-2 control-label"
       .col-lg-4
         .input-group
-          = password_field_tag :answer, '', class: "form-control"
+          = password_field_tag :answer, '', class: "form-control", autocomplete: :nope
           = render 'notices/show_password', key: '#answer'
       .col-lg-6
         = render 'callout', section: 'notices', key: 'answer'

--- a/app/views/public/read.html.slim
+++ b/app/views/public/read.html.slim
@@ -5,8 +5,10 @@
     p.lead
       == markdown(emojify(@data))
   .panel-footer
-    a.glyphicon.glyphicon-info-sign.info data-html="true" data-container="body" data-toggle="popover" data-placement="auto" data-content=t('public.policy_content') title=@notice.policy.name.humanize
-    small<= t('public.this_will_self_destruct')
+    = link_to t('public.download_as_file'), "data:text/plain;charset=utf-8,#{URI.encode(@data)}", download: "#{@notice.question.parameterize}.txt", class: "btn btn-default btn-xs"
+    .pull-right
+      a.glyphicon.glyphicon-info-sign.info data-html="true" data-container="body" data-toggle="popover" data-placement="auto" data-content=t('public.policy_content') title=@notice.policy.name.humanize
+      small<= t('public.this_will_self_destruct')
 
 hr.spacer
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -129,6 +129,7 @@ de:
     please_enter_secret: 'Gib die geheime Antwort zum Entschlüsseln ein!'
     no_longer_available: 'Die Nachricht ist nicht länger verfügbar!'
     answer_button: 'beantworten und lesen'
+    download_as_file: 'Als Datei speichern'
     too_many_attempts: 'Die Nachricht wurde wegen zu vieler falscher Zugriffsversuche deaktiviert!'
     invalid_answer: 'Die geheime Antwort war nicht korrekt!'
     correct_answer: 'Die Antwort war korrekt, Entschlüsselung erfolgreich!'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
     please_enter_secret: 'Please enter your shared secret!'
     no_longer_available: 'The Burn-Notice is not available any longer!'
     answer_button: 'answer and read'
+    download_as_file: 'Save as file'
     too_many_attempts: 'The notice has been disabled due to too many invalid attempts!'
     invalid_answer: 'The secret answer was incorrect!'
     correct_answer: 'Your answer was correct, encryption was successful!'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   scope '/p' do
     get  '/open/:token',  to: 'public#open',  as: :open
     post '/read',         to: 'public#read',  as: :read
+    get  '/read_public',  to: 'public#read_public' if Rails.env.development?
   end
 
   scope '/auth' do


### PR DESCRIPTION
adding a button that will download the text into a file, closes #23 

<img width="432" alt="screen shot 2016-10-28 at 21 57 36" src="https://cloud.githubusercontent.com/assets/48745/19820422/9a6f599a-9d59-11e6-8beb-b784327ad557.png">
